### PR TITLE
#32 [feat] CreateAcitivity post APi 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,7 +14,7 @@
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/font/roboto.xml" value="0.240625" />
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/activity_create.xml" value="0.25555555555555554" />
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/activity_home.xml" value="0.22" />
-        <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/activity_read.xml" value="0.35" />
+        <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/activity_read.xml" value="0.14666666666666667" />
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/bottom_sheet_state.xml" value="0.23125" />
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/item_image_list.xml" value="1.0" />
         <entry key="..\:/github/CarrotIsDelicious-AOS/app/src/main/res/layout/item_read_vp_item.xml" value="0.23125" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.CarrotIsDelicious">
         <activity
             android:name=".ui.read.ReadActivity"
@@ -26,6 +27,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/sopt/carrot16_2/data/remote/RetrofitBuilder.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/data/remote/RetrofitBuilder.kt
@@ -6,7 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitBuilder {
-    private const val BASE_URL = "https://83008f6f-c9e8-4bb3-a1f8-db102f7e9b13.mock.pstmn.io"
+    private const val BASE_URL = "http://13.125.157.62:8000/"
 
     private val retrofit: Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)

--- a/app/src/main/java/org/sopt/carrot16_2/data/remote/RetrofitBuilder.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/data/remote/RetrofitBuilder.kt
@@ -1,5 +1,6 @@
 package org.sopt.carrot16_2.data.remote
 
+import org.sopt.carrot16_2.data.remote.service.CreateService
 import org.sopt.carrot16_2.data.remote.service.ReadService
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -14,4 +15,5 @@ object RetrofitBuilder {
 
     // val sampleService: SampleService = retrofit.create(SampleService::class.java)
     val readService: ReadService = retrofit.create(ReadService::class.java)
+    val createService : CreateService = retrofit.create(CreateService::class.java)
 }

--- a/app/src/main/java/org/sopt/carrot16_2/data/remote/entity/request/CreateRequest.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/data/remote/entity/request/CreateRequest.kt
@@ -1,0 +1,10 @@
+package org.sopt.carrot16_2.data.remote.entity.request
+
+data class CreateRequest(
+    val imageCount : Int,
+    val title : String,
+    val category : String,
+    val price : Int,
+    val contents : String,
+    val isPriceSuggestion : Boolean
+)

--- a/app/src/main/java/org/sopt/carrot16_2/data/remote/entity/response/CreateResponse.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/data/remote/entity/response/CreateResponse.kt
@@ -1,0 +1,12 @@
+package org.sopt.carrot16_2.data.remote.entity.response
+
+data class CreateResponse (
+    val status : Int,
+    val success : Boolean,
+    val message : String,
+    val data : Data
+){
+    data class Data(
+        val id : String
+    )
+}

--- a/app/src/main/java/org/sopt/carrot16_2/data/remote/service/CreateService.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/data/remote/service/CreateService.kt
@@ -1,0 +1,14 @@
+package org.sopt.carrot16_2.data.remote.service
+
+import org.sopt.carrot16_2.data.remote.entity.request.CreateRequest
+import org.sopt.carrot16_2.data.remote.entity.response.CreateResponse
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface CreateService {
+    @POST("feed")
+    fun postCreate(
+        @Body body : CreateRequest
+    ): Call<CreateResponse>
+}

--- a/app/src/main/java/org/sopt/carrot16_2/ui/create/CreateActivity.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/ui/create/CreateActivity.kt
@@ -2,6 +2,7 @@ package org.sopt.carrot16_2.ui.create
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
 import org.sopt.carrot16_2.R
@@ -92,24 +93,19 @@ class CreateActivity : BaseActivity<ActivityCreateBinding>(R.layout.activity_cre
             val call : Call<CreateResponse> = RetrofitBuilder.createService.postCreate(createRequest)
             call.enqueueUtil(
                 onSuccess = {
-                    val intent = Intent(this@CreateActivity, ReadActivity::class.java).apply {
-                        putExtra("title",createRequest.title)
-                        putExtra("category",createRequest.category)
-                        putExtra("price", createRequest.price)
-                        putExtra("contents",createRequest.contents)
-                        putExtra("isPrice", createRequest.isPriceSuggestion)
-                    }
+                    val data = it.data
                     Toast.makeText(this@CreateActivity, "게시글 업로드 성공",Toast.LENGTH_SHORT).show()
-                    setResult(RESULT_OK,intent)
-                    if (!isFinishing) {
-                        finish()
+                    Log.e("dk",createRequest.toString())
+                    val intent = Intent(this@CreateActivity, ReadActivity::class.java).apply {
+                        putExtra("id",data.id)
                     }
+                    startActivity(intent)
+                    finish()
                 },
                 onError = {
                     Toast.makeText(this@CreateActivity, "게시글 업로드 실패",Toast.LENGTH_SHORT).show()
                 }
             )
-
         }
     }
 

--- a/app/src/main/java/org/sopt/carrot16_2/ui/create/viewmodel/CreateViewModel.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/ui/create/viewmodel/CreateViewModel.kt
@@ -12,15 +12,6 @@ class CreateViewModel : ViewModel() {
 
     val complete : MutableLiveData<Boolean> get() = _complete
 
-    /* fun imageComplete() {
-          when {
-              !title.value.isNullOrBlank() && !category.value.isNullOrBlank() && !money.value.isNullOrBlank() && !post.value.isNullOrBlank() -> {
-                  _complete.value = true
-              }
-              else -> {
-                  _complete.value = false
-              }
-          }
-      }*/
+
 
 }

--- a/app/src/main/java/org/sopt/carrot16_2/ui/read/ReadActivity.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/ui/read/ReadActivity.kt
@@ -23,28 +23,6 @@ class ReadActivity : BaseActivity<ActivityReadBinding>(R.layout.activity_read) {
         super.onCreate(savedInstanceState)
         binding.readViewModel = readViewModel
 
-        getCreateActivityResult = registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult()){
-            result ->
-            if(result.resultCode == RESULT_OK){
-                val getTitle = result.data?.getStringExtra("title")
-                val getCategory = result.data?.getStringExtra("category")
-                val getPrice = result.data?.getStringExtra("price")?.toInt()
-                val getContents = result.data?.getStringExtra("contents")
-                val getIsPrice = result.data?.getStringExtra("isPrice").toBoolean()
-
-                binding.tvReadTitle.text = getTitle
-                binding.tvReadCategory.text = getCategory
-                binding.tvReadContent.text = getContents
-                binding.tvReadPrice.text = getPrice.toString()
-                if(getIsPrice){
-                    binding.tvReadNegotiation.text = R.string.item_no_sug_money.toString()
-                }else{
-                    binding.tvReadNegotiation.text = R.string.item_sug_money.toString()
-                }
-            }
-        }
-
         initReadId()
         initReadItem()
         initViewPagerAdapter()

--- a/app/src/main/java/org/sopt/carrot16_2/ui/read/ReadActivity.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/ui/read/ReadActivity.kt
@@ -1,6 +1,9 @@
 package org.sopt.carrot16_2.ui.read
 
+import android.content.Intent
 import android.os.Bundle
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.viewpager2.widget.ViewPager2
 import org.sopt.carrot16_2.R
@@ -14,10 +17,33 @@ class ReadActivity : BaseActivity<ActivityReadBinding>(R.layout.activity_read) {
     private lateinit var readViewPagerAdapter: ReadViewPagerAdapter
     private val readViewModel by viewModels<ReadViewModel>()
     private var readId by Delegates.notNull<Int>()
+    private lateinit var getCreateActivityResult : ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.readViewModel = readViewModel
+
+        getCreateActivityResult = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()){
+            result ->
+            if(result.resultCode == RESULT_OK){
+                val getTitle = result.data?.getStringExtra("title")
+                val getCategory = result.data?.getStringExtra("category")
+                val getPrice = result.data?.getStringExtra("price")?.toInt()
+                val getContents = result.data?.getStringExtra("contents")
+                val getIsPrice = result.data?.getStringExtra("isPrice").toBoolean()
+
+                binding.tvReadTitle.text = getTitle
+                binding.tvReadCategory.text = getCategory
+                binding.tvReadContent.text = getContents
+                binding.tvReadPrice.text = getPrice.toString()
+                if(getIsPrice){
+                    binding.tvReadNegotiation.text = R.string.item_no_sug_money.toString()
+                }else{
+                    binding.tvReadNegotiation.text = R.string.item_sug_money.toString()
+                }
+            }
+        }
 
         initReadId()
         initReadItem()

--- a/app/src/main/java/org/sopt/carrot16_2/util/EnqueueUtil.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/util/EnqueueUtil.kt
@@ -1,0 +1,25 @@
+package org.sopt.carrot16_2.util
+
+import android.util.Log
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+fun <ResponseType> Call<ResponseType>.enqueueUtil(
+    onSuccess: (ResponseType) -> (Unit),
+    onError:((stateCode:Int) -> Unit)? = null
+){
+    this.enqueue(object : Callback<ResponseType>{
+        override fun onResponse(call: Call<ResponseType>, response: Response<ResponseType>) {
+            if(response.isSuccessful){
+                onSuccess.invoke(response.body() ?: return)
+            }else{
+                onError?.invoke(response.code())
+            }
+        }
+
+        override fun onFailure(call: Call<ResponseType>, t: Throwable) {
+            Log.d("NetworkTest","error:$t")
+        }
+    })
+}

--- a/app/src/main/java/org/sopt/carrot16_2/util/EnqueueUtil.kt
+++ b/app/src/main/java/org/sopt/carrot16_2/util/EnqueueUtil.kt
@@ -13,8 +13,11 @@ fun <ResponseType> Call<ResponseType>.enqueueUtil(
         override fun onResponse(call: Call<ResponseType>, response: Response<ResponseType>) {
             if(response.isSuccessful){
                 onSuccess.invoke(response.body() ?: return)
+                Log.e("rrrrrrrrrrrr",response.code().toString())
+                Log.e("rrrrrrrrrrrr",response.body().toString())
             }else{
                 onError?.invoke(response.code())
+                Log.e("rrrrrrrrrrrr",response.code().toString())
             }
         }
 

--- a/app/src/main/res/layout/activity_create.xml
+++ b/app/src/main/res/layout/activity_create.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="create"
-            type="org.sopt.carrot16_2.viewModel.CreateViewModel" />
+            type="org.sopt.carrot16_2.ui.create.viewmodel.CreateViewModel" />
 
         <variable
             name="createViewModel"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="item_won">&#65510;</string>
     <string name="item_money">가격</string>
     <string name="item_sug_money">가격 제안받기</string>
+    <string name="item_no_sug_money">가격 제안 불가</string>
     <string name="item_write">게시글을 작성해주세요.</string>
     <string name="item_word">자주 쓰는 문구</string>
     <string name="item_town">보여줄 동네 설정</string>


### PR DESCRIPTION
## 관련 이슈번호
- Closed #32 
## 화면 이름
CreateActivity
## 완료 태스크
- createActivity post API 연결 
- 데이터 전송 후 ReadActivty에 정보 전달하여 설정하기
